### PR TITLE
Add dual currency support with USD conversion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,22 +8,41 @@ import { getNumber, setNumber, getJSON, setJSON } from './lib/storage';
 import { currentYearMonth, dateKey } from './lib/date';
 import { computeMonthMetrics } from './lib/calc';
 import type { DayMetric } from './lib/calc';
-import { formatARS } from './lib/money';
+import type { Currency } from './lib/money';
+import { formatMoney } from './lib/money';
 
 function App() {
+  const [currency, setCurrency] = useState<Currency>(() =>
+    getJSON('bt.currency', 'ARS'),
+  );
+  const [rate, setRate] = useState(1);
   const [salary, setSalary] = useState(() => getNumber('bt.salary', 0));
-  const [desiredSavings, setDesiredSavings] = useState(() => getNumber('bt.desiredSavings', 0));
-  const [fixedList, setFixedList] = useState<FixedItem[]>(() => getJSON('bt.fixedList', []));
-  const [yearMonth, setYearMonth] = useState(() => getJSON('bt.yearMonth', currentYearMonth()));
+  const [desiredSavings, setDesiredSavings] = useState(() =>
+    getNumber('bt.desiredSavings', 0),
+  );
+  const [fixedList, setFixedList] = useState<FixedItem[]>(() =>
+    getJSON('bt.fixedList', []),
+  );
+  const [yearMonth, setYearMonth] = useState(() =>
+    getJSON('bt.yearMonth', currentYearMonth()),
+  );
   const [spendMap, setSpendMap] = useState<Record<string, number>>(() =>
-    getJSON(`bt.spend.${yearMonth}`, {})
+    getJSON(`bt.spend.${yearMonth}`, {}),
   );
 
+  useEffect(() => setJSON('bt.currency', currency), [currency]);
   useEffect(() => setNumber('bt.salary', salary), [salary]);
   useEffect(() => setNumber('bt.desiredSavings', desiredSavings), [desiredSavings]);
   useEffect(() => setJSON('bt.fixedList', fixedList), [fixedList]);
   useEffect(() => setJSON('bt.yearMonth', yearMonth), [yearMonth]);
   useEffect(() => setJSON(`bt.spend.${yearMonth}`, spendMap), [spendMap, yearMonth]);
+
+  useEffect(() => {
+    fetch('https://open.er-api.com/v6/latest/USD')
+      .then((r) => r.json())
+      .then((data) => setRate(data.rates.ARS))
+      .catch(() => setRate(1));
+  }, []);
 
   useEffect(() => {
     setSpendMap(getJSON(`bt.spend.${yearMonth}`, {}));
@@ -121,48 +140,105 @@ function App() {
         <h2 className="text-xl font-semibold">Config</h2>
         <div className="space-y-2">
           <div className="flex gap-2 flex-wrap">
+            <label className="flex flex-col min-w-40">
+              <span className="text-sm">Moneda</span>
+              <select
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value as Currency)}
+                className="border rounded px-2 py-1"
+              >
+                <option value="ARS">ARS</option>
+                <option value="USD">USD</option>
+              </select>
+            </label>
             <label className="flex flex-col flex-1 min-w-40">
-              <span className="text-sm">Salario mensual (ARS)</span>
+              <span className="text-sm">Salario mensual ({currency})</span>
               <input
-                type="number"
                 aria-label="Salario mensual"
-                value={salary}
-                onChange={(e) => setSalary(Number(e.target.value))}
+                value={
+                  currency === 'ARS'
+                    ? salary
+                    : (salary / rate).toFixed(2)
+                }
+                onChange={(e) =>
+                  setSalary(
+                    Number(e.target.value) * (currency === 'ARS' ? 1 : rate),
+                  )
+                }
                 className="border rounded px-2 py-1"
               />
             </label>
             <label className="flex flex-col flex-1 min-w-40">
-              <span className="text-sm">Ahorro deseado (ARS)</span>
+              <span className="text-sm">Ahorro deseado ({currency})</span>
               <input
-                type="number"
                 aria-label="Ahorro deseado"
-                value={desiredSavings}
-                onChange={(e) => setDesiredSavings(Number(e.target.value))}
+                value={
+                  currency === 'ARS'
+                    ? desiredSavings
+                    : (desiredSavings / rate).toFixed(2)
+                }
+                onChange={(e) =>
+                  setDesiredSavings(
+                    Number(e.target.value) * (currency === 'ARS' ? 1 : rate),
+                  )
+                }
                 className="border rounded px-2 py-1"
               />
             </label>
           </div>
           <div>
             <h3 className="font-semibold mb-1">Gastos fijos</h3>
-            <FixedList items={fixedList} onChange={setFixedList} />
-            <div className="text-sm mt-1">Total fijos: {formatARS(fixedTotal)}</div>
+            <FixedList
+              items={fixedList}
+              onChange={setFixedList}
+              currency={currency}
+              rate={rate}
+            />
+            <div className="text-sm mt-1">
+              Total fijos: {formatMoney(fixedTotal, currency, rate)}
+            </div>
           </div>
         </div>
       </section>
 
       <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <KPICard label="Fijos del mes" value={fixedTotal} />
-        <KPICard label="Variable disponible" value={variableBudget} />
-        <KPICard label="Gastado variable" value={variableSpent} />
-        <KPICard label="Restante variable" value={variableRemaining} />
+        <KPICard
+          label="Fijos del mes"
+          value={fixedTotal}
+          currency={currency}
+          rate={rate}
+        />
+        <KPICard
+          label="Variable disponible"
+          value={variableBudget}
+          currency={currency}
+          rate={rate}
+        />
+        <KPICard
+          label="Gastado variable"
+          value={variableSpent}
+          currency={currency}
+          rate={rate}
+        />
+        <KPICard
+          label="Restante variable"
+          value={variableRemaining}
+          currency={currency}
+          rate={rate}
+        />
       </section>
 
       <section>
-        <MonthTable metrics={metrics} onChange={handleSpendChange} />
+        <MonthTable
+          metrics={metrics}
+          onChange={handleSpendChange}
+          currency={currency}
+          rate={rate}
+        />
       </section>
 
       <section>
-        <TodayPanel info={todayInfo} />
+        <TodayPanel info={todayInfo} currency={currency} rate={rate} />
       </section>
     </div>
   );

--- a/src/components/FixedList.tsx
+++ b/src/components/FixedList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { formatARS } from '../lib/money';
+import type { Currency } from '../lib/money';
+import { formatMoney } from '../lib/money';
 
 export interface FixedItem {
   id: string;
@@ -10,9 +11,11 @@ export interface FixedItem {
 interface Props {
   items: FixedItem[];
   onChange: (items: FixedItem[]) => void;
+  currency: Currency;
+  rate: number;
 }
 
-const FixedList = ({ items, onChange }: Props) => {
+const FixedList = ({ items, onChange, currency, rate }: Props) => {
   const [nombre, setNombre] = useState('');
   const [monto, setMonto] = useState('');
 
@@ -21,7 +24,7 @@ const FixedList = ({ items, onChange }: Props) => {
     const newItem: FixedItem = {
       id: crypto.randomUUID(),
       nombre,
-      montoARS: Number(monto),
+      montoARS: Number(monto) * (currency === 'ARS' ? 1 : rate),
     };
     onChange([...items, newItem]);
     setNombre('');
@@ -38,7 +41,7 @@ const FixedList = ({ items, onChange }: Props) => {
         {items.map((item) => (
           <li key={item.id} className="flex items-center gap-2">
             <span className="flex-1">{item.nombre}</span>
-            <span>{formatARS(item.montoARS)}</span>
+            <span>{formatMoney(item.montoARS, currency, rate)}</span>
             <button
               onClick={() => remove(item.id)}
               aria-label="Eliminar gasto fijo"
@@ -59,11 +62,10 @@ const FixedList = ({ items, onChange }: Props) => {
         />
         <input
           aria-label="Monto gasto fijo"
-          type="number"
           value={monto}
           onChange={(e) => setMonto(e.target.value)}
           className="border rounded px-2 py-1 w-28"
-          placeholder="ARS"
+          placeholder={currency}
         />
         <button
           onClick={addItem}

--- a/src/components/KPICard.tsx
+++ b/src/components/KPICard.tsx
@@ -1,14 +1,19 @@
-import { formatARS } from '../lib/money';
+import type { Currency } from '../lib/money';
+import { formatMoney } from '../lib/money';
 
 interface Props {
   label: string;
   value: number;
+  currency: Currency;
+  rate: number;
 }
 
-const KPICard = ({ label, value }: Props) => (
+const KPICard = ({ label, value, currency, rate }: Props) => (
   <div className="p-4 rounded-2xl bg-white shadow-sm flex flex-col">
     <span className="text-sm text-slate-500">{label}</span>
-    <span className="text-xl font-bold">{formatARS(value)}</span>
+    <span className="text-xl font-bold">
+      {formatMoney(value, currency, rate)}
+    </span>
   </div>
 );
 

--- a/src/components/MonthTable.tsx
+++ b/src/components/MonthTable.tsx
@@ -1,12 +1,15 @@
 import type { DayMetric } from '../lib/calc';
-import { formatARS } from '../lib/money';
+import type { Currency } from '../lib/money';
+import { formatMoney } from '../lib/money';
 
 interface Props {
   metrics: DayMetric[];
   onChange: (key: string, value: number) => void;
+  currency: Currency;
+  rate: number;
 }
 
-const MonthTable = ({ metrics, onChange }: Props) => (
+const MonthTable = ({ metrics, onChange, currency, rate }: Props) => (
   <div className="overflow-x-auto">
     <table className="min-w-full text-sm">
       <thead>
@@ -37,17 +40,28 @@ const MonthTable = ({ metrics, onChange }: Props) => (
               <td className="p-2 capitalize">{m.weekday}</td>
               <td className="p-2">
                 <input
-                  type="number"
                   aria-label={`Gasto ${m.dateKey}`}
-                  value={m.gastoDia}
-                  onChange={(e) => onChange(m.dateKey, Number(e.target.value))}
+                  value={
+                    currency === 'ARS'
+                      ? m.gastoDia
+                      : (m.gastoDia / rate).toFixed(2)
+                  }
+                  onChange={(e) =>
+                    onChange(
+                      m.dateKey,
+                      Number(e.target.value) *
+                        (currency === 'ARS' ? 1 : rate),
+                    )
+                  }
                   className={`w-24 px-2 py-1 rounded ${inputColor}`}
                 />
               </td>
-              <td className="p-2">{formatARS(m.gastoAcumulado)}</td>
+              <td className="p-2">{formatMoney(m.gastoAcumulado, currency, rate)}</td>
               <td className="p-2">{m.diasRestantes}</td>
-              <td className="p-2">{formatARS(Math.max(m.presupuestoRestante, 0))}</td>
-              <td className="p-2">{formatARS(m.cupoDeHoy)}</td>
+              <td className="p-2">
+                {formatMoney(Math.max(m.presupuestoRestante, 0), currency, rate)}
+              </td>
+              <td className="p-2">{formatMoney(m.cupoDeHoy, currency, rate)}</td>
               <td className="p-2">
                 {m.estado && (
                   <span
@@ -61,8 +75,12 @@ const MonthTable = ({ metrics, onChange }: Props) => (
                   </span>
                 )}
               </td>
-              <td className={`p-2 ${m.desvio >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {formatARS(m.desvio)}
+              <td
+                className={`p-2 ${
+                  m.desvio >= 0 ? 'text-green-600' : 'text-red-600'
+                }`}
+              >
+                {formatMoney(m.desvio, currency, rate)}
               </td>
             </tr>
           );

--- a/src/components/TodayPanel.tsx
+++ b/src/components/TodayPanel.tsx
@@ -1,18 +1,21 @@
 import type { DayMetric } from '../lib/calc';
-import { formatARS } from '../lib/money';
+import type { Currency } from '../lib/money';
+import { formatMoney } from '../lib/money';
 
 interface Props {
   info: DayMetric | undefined;
+  currency: Currency;
+  rate: number;
 }
 
-const TodayPanel = ({ info }: Props) => {
+const TodayPanel = ({ info, currency, rate }: Props) => {
   if (!info) return null;
   return (
     <div className="p-4 rounded-2xl bg-white shadow-sm">
       <h3 className="font-bold mb-2">Hoy</h3>
       <div className="space-y-1 text-sm">
-        <div>Cupo de hoy: {formatARS(info.cupoDeHoy)}</div>
-        <div>Gastado hoy: {formatARS(info.gastoDia)}</div>
+        <div>Cupo de hoy: {formatMoney(info.cupoDeHoy, currency, rate)}</div>
+        <div>Gastado hoy: {formatMoney(info.gastoDia, currency, rate)}</div>
         <div>
           Estado:{' '}
           {info.estado ? (
@@ -29,7 +32,9 @@ const TodayPanel = ({ info }: Props) => {
             '—'
           )}
         </div>
-        <div>Restante mes: {formatARS(Math.max(info.presupuestoRestante, 0))}</div>
+        <div>
+          Restante mes: {formatMoney(Math.max(info.presupuestoRestante, 0), currency, rate)}
+        </div>
         <div>Días restantes: {info.diasRestantes}</div>
       </div>
     </div>

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,6 +1,20 @@
+export type Currency = 'ARS' | 'USD';
+
+export const formatMoney = (
+  value: number,
+  currency: Currency,
+  rate: number,
+): string => {
+  const amount = currency === 'ARS' ? value : value / rate;
+  return amount.toLocaleString(
+    currency === 'ARS' ? 'es-AR' : 'en-US',
+    {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: currency === 'ARS' ? 0 : 2,
+    },
+  );
+};
+
 export const formatARS = (value: number): string =>
-  value.toLocaleString('es-AR', {
-    style: 'currency',
-    currency: 'ARS',
-    maximumFractionDigits: 0,
-  });
+  formatMoney(value, 'ARS', 1);


### PR DESCRIPTION
## Summary
- add ARS/USD currency selector and fetch live exchange rate
- format and convert money values based on selected currency
- change amount inputs to plain text fields to remove steppers

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab7ae527c8324b47cad946300e17c